### PR TITLE
Upgrade JNA to latest version to avoid problems when running gigaspac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <oshi.version>5.5.0</oshi.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <jna.version>5.6.0</jna.version>
+        <jna.version>5.13.0</jna.version>
         <spring.version>5.3.19</spring.version>
         <spring.security.version>5.6.2</spring.security.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
…es tests using testcontainers on apple mac M1

The 5.6.0 version of jna doesn't work on apple mac m1, this is fixed in 5.7.0, but this commit suggests upgrading to the latest version, which currently is 5.13.0

jna has no transitive dependencies and jna release notes does not mention any problems upgrading to 5.13.0

for more info:

https://github.com/java-native-access/jna/blob/master/CHANGES.md https://github.com/java-native-access/jna/pull/1238 https://www.testcontainers.org/

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
